### PR TITLE
Use getDate instead of getDay while formatting date to string

### DIFF
--- a/imports/utils/index.ts
+++ b/imports/utils/index.ts
@@ -15,5 +15,5 @@ export const getAgeInYears = (date: Date | undefined): number => {
 };
 
 export const formatDateToString = (date: Date): string => {
-  return `${months[date.getMonth()]} ${date.getDay()}, ${date.getFullYear()}`;
+  return `${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
 };


### PR DESCRIPTION
Hi!

Small fix to display dates correctly in the Versions panel.

Fixing:
![image](https://user-images.githubusercontent.com/5058992/129469680-94f72f01-61c2-48b5-b078-54f2916e1fea.png)

